### PR TITLE
[LCSV-001] release: 모델 추가 및 전반적인 리팩터링 (LlmApiServerRelease02/10)

### DIFF
--- a/.env
+++ b/.env
@@ -7,3 +7,4 @@ SAMBANOVA_API_KEY=api-key
 SECRET_KEY=secret-key
 MISTRAL_API_KEY=api-key
 ANTHROPIC_API_KEY=api-key
+DEEPSEEK_API_KEY=api-key

--- a/.env
+++ b/.env
@@ -6,3 +6,4 @@ GOOGLE_API_KEY=api-key
 SAMBANOVA_API_KEY=api-key
 SECRET_KEY=secret-key
 MISTRAL_API_KEY=api-key
+ANTHROPIC_API_KEY=api-key

--- a/README.md
+++ b/README.md
@@ -26,7 +26,14 @@
 
 ## 📚 관련 URL
 - [서버 API](https://hyobin-llm.duckdns.org/docs)
+- [LLM Streaming API 클라이언트 서버 API](https://hyobin-llm-client.duckdns.org/swagger-ui/index.html)
+- [서비스 URL](https://hyobin-llm.vercel.app)
+- [LLM Streaming 서버 Repository](https://github.com/hellmir/LLM-Streaming-Server)
+- [LLM Streaming 클라이언트 Repository](https://github.com/hellmir/LLM-Streaming-Client)
   <br><br>
+
+## 🗼 Architecture
+![llm-service](https://github.com/user-attachments/assets/6706f365-c4ad-4f09-bb43-7aebcbe5477b)
 
 ## 🛠️ Skills
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
   <br><br>
 
 ## 🗼 Architecture
-![llm-service](https://github.com/user-attachments/assets/6706f365-c4ad-4f09-bb43-7aebcbe5477b)
+![llm-service](https://github.com/user-attachments/assets/352ceaf8-9576-4207-9e92-00d0465eaf1b)
 
 ## 🛠️ Skills
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@
 - HCX-003
 - Gemini 1.5 Pro
 - GPT 3.5 Turbo
-  <br><br>
+<br><br>
+
+## 📼 서비스 시연
+![hyobin-llm](https://github.com/user-attachments/assets/f62ff497-d639-4176-b21a-e29d6cda76bd)
+<br><br>
 
 ## 📅 프로젝트 기간
 <b>2025. 01. 26 ~ 2025. 01. 28</b>

--- a/README.md
+++ b/README.md
@@ -4,10 +4,12 @@
 
 ### 다양한 생성형 AI 모델의 스트리밍 서비스를 제공하는 서버
 - Mistral Large
-- Llama3.3
-- HCX-003
 - Gemini 1.5 Pro
+- Llama 3.3
+- HCX-003
 - GPT 3.5 Turbo
+- Claude Haiku
+- DeepSeek V3
 <br><br>
 
 ## 📼 서비스 시연
@@ -19,7 +21,7 @@
 <br><br>
 
 ## ![Image](https://github.com/user-attachments/assets/1838d6b9-69ff-43fe-80b1-b1e39709cef9) 모델 추가 및 리팩터링
-<b>2025. 01. 30</b>
+<b>2025. 01. 30, 2025. 02. 10</b>
 <br><br>
 
 ## 👫 구성원
@@ -29,16 +31,17 @@
   <br>
 
 ## 📚 관련 URL
-- [서버 API](https://hyobin-llm.duckdns.org/docs)
-- [LLM Streaming API 클라이언트 서버 API](https://hyobin-llm-client.duckdns.org/swagger-ui/index.html)
 - [서비스 URL](https://hyobin-llm.vercel.app)
-- [LLM Streaming 서버 Repository](https://github.com/hellmir/LLM-Streaming-Server)
-- [LLM Streaming 클라이언트 Repository](https://github.com/hellmir/LLM-Streaming-Client)
+- [LLM Streaming 서버 API](https://hyobin-llm.duckdns.org/docs)
+- [LLM Spring API 클라이언트 서버 API](https://hyobin-llm-spring.duckdns.org/swagger-ui/index.html)
+- [LLM Nest.js API 클라이언트 서버 API](https://hyobin-llm-nest.duckdns.org/api)
+- [LLM 클라이언트 Repository](https://github.com/hellmir/LLM-Streaming-Client)
+- [LLM Spring API 클라이언트 서버 Repository](https://github.com/hellmir/LLM-Spring-API-Client)
+- [LLM Nest API 클라이언트 서버 Repository](https://github.com/hellmir/LLM-Nest-API-Client)
   <br><br>
 
 ## 🗼 Architecture
-![llm-service](https://github.com/user-attachments/assets/352ceaf8-9576-4207-9e92-00d0465eaf1b)
-
+![llm-service](https://github.com/user-attachments/assets/c63002e7-8260-4cd8-99de-7cbd4ab4d850)
 ## 🛠️ Skills
 
 ## Back-End
@@ -54,6 +57,8 @@
 - ChatClovaX
 - ChatGoogleGenerativeAI
 - ChatOpenAI
+- ChatAnthropic
+- ChatDeepSeek
 
 ## DevOps
 
@@ -277,3 +282,46 @@
 [LCSV-39](https://langchain.atlassian.net/browse/LCSV-39) README.md 추가
 
 [LCSV-60](https://langchain.atlassian.net/browse/LCSV-60) llm\_picker 모듈 리팩터링
+<br><br>
+
+## 릴리스 정보 - LangChain Service - LlmApiServerRelease02/10
+
+### 하위 작업
+
+[LCSV-77](https://langchain.atlassian.net/browse/LCSV-77) API 키 발급
+
+[LCSV-78](https://langchain.atlassian.net/browse/LCSV-78) ChatAnthropic 패키지 설치
+
+[LCSV-79](https://langchain.atlassian.net/browse/LCSV-79) claude-3-haiku 모델 적용
+
+[LCSV-80](https://langchain.atlassian.net/browse/LCSV-80) Swagger 문서 업데이트
+
+[LCSV-82](https://langchain.atlassian.net/browse/LCSV-82) API 키 발급
+
+[LCSV-83](https://langchain.atlassian.net/browse/LCSV-83) ChatDeepSeek 패키지 설치
+
+[LCSV-84](https://langchain.atlassian.net/browse/LCSV-84) deepseek-chat 모델 적용
+
+[LCSV-85](https://langchain.atlassian.net/browse/LCSV-85) Swagger 문서 업데이트
+
+[LCSV-87](https://langchain.atlassian.net/browse/LCSV-87) 모델 순서 변경
+
+[LCSV-88](https://langchain.atlassian.net/browse/LCSV-88) Swagger 문서의 모델 목록 업데이트
+
+[LCSV-89](https://langchain.atlassian.net/browse/LCSV-89) 일부 모델의 온도를 0.7로 조정
+
+[LCSV-90](https://langchain.atlassian.net/browse/LCSV-90) 모든 모델의 최대 토큰 제한을 2,048개로 조정
+
+[LCSV-91](https://langchain.atlassian.net/browse/LCSV-91) 클라이언트의 모델명 대소문자 입력에 영향 받지 않도록 변경
+
+### 스토리
+
+[LCSV-76](https://langchain.atlassian.net/browse/LCSV-76) 클라이언트는 Claude Haiku 모델 API를 사용할 수 있다
+
+[LCSV-81](https://langchain.atlassian.net/browse/LCSV-81) 클라이언트는 DeepSeek V3 모델 API를 사용할 수 있다
+
+[LCSV-86](https://langchain.atlassian.net/browse/LCSV-86) 전반적인 리팩터링
+
+### 작업
+
+[LCSV-39](https://langchain.atlassian.net/browse/LCSV-39) README.md 추가

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@
 
 [LCSV-39](https://langchain.atlassian.net/browse/LCSV-39) README.md 추가
 
-[LCSV-40](https://langchain.atlassian.net/browse/LCSV-40) 클라이언트는 스트리밍을 통한 빠른 응답을 제공 받을 수 있다
+[LCSV-40](https://langchain.atlassian.net/browse/LCSV-40) 클라이언트는 스트리밍을 통한 빠른 응답을 제공받을 수 있다
 <br><br>
 
 ## 릴리스 정보 - LangChain Service - LlmApiServerRelease01/28

--- a/app.py
+++ b/app.py
@@ -20,6 +20,7 @@ app = FastAPI(
     \n  - Gemini
     \n  - GPT
     \n  - Claude 
+    \n  - DeepSeek
     \n </b>
     """,
     version="3.0"

--- a/app.py
+++ b/app.py
@@ -19,6 +19,7 @@ app = FastAPI(
     \n  - ClovaX
     \n  - Gemini
     \n  - GPT
+    \n  - Claude 
     \n </b>
     """,
     version="3.0"

--- a/app.py
+++ b/app.py
@@ -15,9 +15,9 @@ app = FastAPI(
     \n ### 제공 모델
     \n <b>
     \n  - Mistral
+    \n  - Gemini
     \n  - Llama
     \n  - ClovaX
-    \n  - Gemini
     \n  - GPT
     \n  - Claude 
     \n  - DeepSeek

--- a/app.py
+++ b/app.py
@@ -23,7 +23,7 @@ app = FastAPI(
     \n  - DeepSeek
     \n </b>
     """,
-    version="3.0"
+    version="3.1"
 )
 
 app.add_middleware(

--- a/llm_generator.py
+++ b/llm_generator.py
@@ -1,6 +1,7 @@
 from langchain_anthropic import ChatAnthropic
 from langchain_community.chat_models import ChatClovaX
 from langchain_community.llms.sambanova import SambaNovaCloud
+from langchain_deepseek import ChatDeepSeek
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_mistralai import ChatMistralAI
 from langchain_openai import ChatOpenAI
@@ -9,7 +10,7 @@ from langchain_openai import ChatOpenAI
 def generate_samba_nova_cloud():
     return SambaNovaCloud(
         model="Meta-Llama-3.3-70B-Instruct",
-        max_tokens=1024,
+        max_tokens=2_048,
         temperature=0.7,
         top_p=0.9,
         top_k=40
@@ -19,6 +20,8 @@ def generate_samba_nova_cloud():
 def generate_chat_clova_x():
     return ChatClovaX(
         model="HCX-003",
+        temperature=0.7,
+        max_tokens=2_048,
         disable_streaming=False
     )
 
@@ -26,8 +29,8 @@ def generate_chat_clova_x():
 def generate_chat_google_generative_ai():
     return ChatGoogleGenerativeAI(
         model="gemini-1.5-pro",
-        temperature=0,
-        max_output_tokens=200
+        temperature=0.7,
+        max_output_tokens=2_048
     )
 
 
@@ -35,13 +38,16 @@ def generate_chat_open_ai():
     return ChatOpenAI(
         temperature=0,
         model_name="gpt-3.5-turbo",
-        streaming=True
+        streaming=True,
+        max_tokens=2_048
+    )
 
 
 def generate_chat_anthropic():
     return ChatAnthropic(
         model='claude-3-haiku',
         temperature=0,
+        max_tokens=2_048
     )
 
 
@@ -49,6 +55,7 @@ def generate_chat_deep_seek():
     return ChatDeepSeek(
         model="deepseek-chat",
         temperature=0,
+        max_tokens=2_048,
         timeout=None,
         max_retries=2
     )
@@ -57,6 +64,7 @@ def generate_chat_deep_seek():
 def generate_chat_mistral_ai():
     return ChatMistralAI(
         model="mistral-large-latest",
-        temperature=0,
-        max_retries=2,
+        temperature=0.7,
+        max_tokens=2_048,
+        max_retries=2
     )

--- a/llm_generator.py
+++ b/llm_generator.py
@@ -43,6 +43,14 @@ def generate_chat_anthropic():
         model='claude-3-haiku',
         temperature=0,
     )
+
+
+def generate_chat_deep_seek():
+    return ChatDeepSeek(
+        model="deepseek-chat",
+        temperature=0,
+        timeout=None,
+        max_retries=2
     )
 
 

--- a/llm_generator.py
+++ b/llm_generator.py
@@ -1,3 +1,4 @@
+from langchain_anthropic import ChatAnthropic
 from langchain_community.chat_models import ChatClovaX
 from langchain_community.llms.sambanova import SambaNovaCloud
 from langchain_google_genai import ChatGoogleGenerativeAI
@@ -35,6 +36,13 @@ def generate_chat_open_ai():
         temperature=0,
         model_name="gpt-3.5-turbo",
         streaming=True
+
+
+def generate_chat_anthropic():
+    return ChatAnthropic(
+        model='claude-3-haiku',
+        temperature=0,
+    )
     )
 
 

--- a/llm_picker.py
+++ b/llm_picker.py
@@ -16,6 +16,8 @@ def get_llm(llm_type: str):
         return llm_generator.generate_chat_open_ai()
     elif llm_type == "claude":
         return llm_generator.generate_chat_anthropic()
+    elif llm_type == "deepseek":
+        return llm_generator.generate_chat_deep_seek()
     elif llm_type == "mistral":  # 기본 모델을 변경하더라도 get_llm 함수가 변경에 닫혀 있도록 하기 위해 중복 설정
         return llm_generator.generate_chat_mistral_ai()
     else:

--- a/llm_picker.py
+++ b/llm_picker.py
@@ -14,6 +14,8 @@ def get_llm(llm_type: str):
         return llm_generator.generate_chat_google_generative_ai()
     elif llm_type == "gpt":
         return llm_generator.generate_chat_open_ai()
+    elif llm_type == "claude":
+        return llm_generator.generate_chat_anthropic()
     elif llm_type == "mistral":  # 기본 모델을 변경하더라도 get_llm 함수가 변경에 닫혀 있도록 하기 위해 중복 설정
         return llm_generator.generate_chat_mistral_ai()
     else:

--- a/routers.py
+++ b/routers.py
@@ -12,8 +12,9 @@ router = APIRouter(prefix="/streaming")
 
 
 class LLMRequest(BaseModel):
-    llm_type: Optional[str] = Field(default=None, description="LLM 모델 유형(clovax, chatgpt, llama): 미입력 시 기본 모델 사용",
-                                    examples=["mistral", "llama", "clovax", "gemini", "gpt"])
+    llm_type: Optional[str] = Field(default=None,
+                                    description="LLM 모델 유형(mistral, gemini, llama, clovax, gpt, claude, deepseek): 미입력 시 기본 모델 사용",
+                                    examples=["mistral", "gemini", "llama", "clovax", "gpt", "claude", "deepseek"])
     template: str = Field(..., description="요청 프롬프트(요구사항)", examples=["레시피 추천해 줘"])
     options: Optional[Dict[str, List[str]]] = Field(
         default=None,
@@ -44,9 +45,9 @@ from fastapi.responses import StreamingResponse
     다음 파라미터를 전송해 LLM 서비스를 이용할 수 있습니다. 응답은 토큰화하여 Stream 형태로 제공됩니다.
     \n- llm_type: LLM 모델 유형(미입력 시 기본 모델 사용)
     \n  - mistral
+    \n  - gemini
     \n  - llama
     \n  - clovax
-    \n  - gemini
     \n  - gpt
     \n  - claude 
     \n  - deepseek 
@@ -79,10 +80,10 @@ def invoke_llm(request: LLMRequest):
     description="""
     다음 파라미터를 전송해 LLM 서비스를 이용할 수 있습니다. 응답은 최소 단위로 토큰화하여 SSE를 통한 Stream 형태로 제공됩니다.
     \n- llm_type: LLM 모델 유형(미입력 시 기본 모델 사용)
-    \n  - mistral 
+    \n  - mistral
+    \n  - gemini
     \n  - llama
     \n  - clovax
-    \n  - gemini
     \n  - gpt
     \n  - claude 
     \n  - deepseek

--- a/routers.py
+++ b/routers.py
@@ -49,6 +49,7 @@ from fastapi.responses import StreamingResponse
     \n  - gemini
     \n  - gpt
     \n  - claude 
+    \n  - deepseek 
     \n- template: 요청 프롬프트(요구사항)
     \n- options: 요청 프롬프트에 적용할 조건들(선택사항)
     \n  - Key: Array Value 형태로 전송
@@ -84,6 +85,7 @@ def invoke_llm(request: LLMRequest):
     \n  - gemini
     \n  - gpt
     \n  - claude 
+    \n  - deepseek
     \n- template: 요청 프롬프트(요구사항)
     \n- options: 요청 프롬프트에 적용할 조건들(선택사항)
     \n  - Key: Array Value 형태로 전송

--- a/routers.py
+++ b/routers.py
@@ -48,6 +48,7 @@ from fastapi.responses import StreamingResponse
     \n  - clovax
     \n  - gemini
     \n  - gpt
+    \n  - claude 
     \n- template: 요청 프롬프트(요구사항)
     \n- options: 요청 프롬프트에 적용할 조건들(선택사항)
     \n  - Key: Array Value 형태로 전송
@@ -82,6 +83,7 @@ def invoke_llm(request: LLMRequest):
     \n  - clovax
     \n  - gemini
     \n  - gpt
+    \n  - claude 
     \n- template: 요청 프롬프트(요구사항)
     \n- options: 요청 프롬프트에 적용할 조건들(선택사항)
     \n  - Key: Array Value 형태로 전송

--- a/services.py
+++ b/services.py
@@ -12,7 +12,7 @@ def generate_response(llm_type: str, template_content: str, options: str):
         input_variables=["options"],
         template=TEMPLATE_HEADER + template_content + TEMPLATE_FOOTER
     )
-    llm = get_llm(llm_type)
+    llm = get_llm(llm_type.lower())
     chain = prompt | llm
     i = 0
 


### PR DESCRIPTION
## resolve [LCSV-001](https://langchain.atlassian.net/browse/LCSV-1)
## resolve #50

## 릴리스 정보 - LangChain Service - LlmApiServerRelease02/10

### 하위 작업

[LCSV-77](https://langchain.atlassian.net/browse/LCSV-77) API 키 발급

[LCSV-78](https://langchain.atlassian.net/browse/LCSV-78) ChatAnthropic 패키지 설치

[LCSV-79](https://langchain.atlassian.net/browse/LCSV-79) claude-3-haiku 모델 적용

[LCSV-80](https://langchain.atlassian.net/browse/LCSV-80) Swagger 문서 업데이트

[LCSV-82](https://langchain.atlassian.net/browse/LCSV-82) API 키 발급

[LCSV-83](https://langchain.atlassian.net/browse/LCSV-83) ChatDeepSeek 패키지 설치

[LCSV-84](https://langchain.atlassian.net/browse/LCSV-84) deepseek-chat 모델 적용

[LCSV-85](https://langchain.atlassian.net/browse/LCSV-85) Swagger 문서 업데이트

[LCSV-87](https://langchain.atlassian.net/browse/LCSV-87) 모델 순서 변경

[LCSV-88](https://langchain.atlassian.net/browse/LCSV-88) Swagger 문서의 모델 목록 업데이트

[LCSV-89](https://langchain.atlassian.net/browse/LCSV-89) 일부 모델의 온도를 0.7로 조정

[LCSV-90](https://langchain.atlassian.net/browse/LCSV-90) 모든 모델의 최대 토큰 제한을 2,048개로 조정

[LCSV-91](https://langchain.atlassian.net/browse/LCSV-91) 클라이언트의 모델명 대소문자 입력에 영향 받지 않도록 변경

### 스토리

[LCSV-76](https://langchain.atlassian.net/browse/LCSV-76) 클라이언트는 Claude Haiku 모델 API를 사용할 수 있다

[LCSV-81](https://langchain.atlassian.net/browse/LCSV-81) 클라이언트는 DeepSeek V3 모델 API를 사용할 수 있다

[LCSV-86](https://langchain.atlassian.net/browse/LCSV-86) 전반적인 리팩터링

### 작업

[LCSV-39](https://langchain.atlassian.net/browse/LCSV-39) README.md 추가